### PR TITLE
feat: 모킹시 유저는 항상 게스트로 입장되는 플래그 작성

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# .editorconfig
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "endOfLine": "auto"
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@nestjs/testing": "^11.0.12",
     "class-validator": "^0.14.1",
     "cookie-parser": "^1.4.7",
-    "nanoid": "^5.1.5",
+    "nanoid": "^3.3.4",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
     "swagger-ui-express": "^5.0.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^1.4.7
         version: 1.4.7
       nanoid:
-        specifier: ^5.1.5
-        version: 5.1.5
+        specifier: ^3.3.4
+        version: 3.3.4
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -2262,9 +2262,9 @@ packages:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  nanoid@5.1.5:
-    resolution: {integrity: sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==}
-    engines: {node: ^18 || >=20}
+  nanoid@3.3.4:
+    resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
   natural-compare@1.4.0:
@@ -5587,7 +5587,7 @@ snapshots:
 
   mute-stream@2.0.0: {}
 
-  nanoid@5.1.5: {}
+  nanoid@3.3.4: {}
 
   natural-compare@1.4.0: {}
 

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -12,7 +12,7 @@ interface RequestWithCookies extends Request {
 }
 
 @ApiTags('Auth')
-@Controller('user/kakao')
+@Controller('user')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
@@ -21,7 +21,7 @@ export class AuthController {
    * nanoid 로 state 생성 후 카카오 Oauth URL 로 리디렉션.
    * @param res
    */
-  @Get('authorize')
+  @Get('kakao/authorize')
   async redirectToKakao(@Res() res: Response) {
     try {
       const state = nanoid();
@@ -58,7 +58,7 @@ export class AuthController {
    * @param req
    * @param res
    */
-  @Get('callback')
+  @Get('kakao/callback')
   async handleKakaoCallback(
     @Query('state') state: string,
     @Query('code') code: string,
@@ -113,6 +113,17 @@ export class AuthController {
       // 실패시에도 홈으로 리디렉션
       console.error('Spring 연동 실패:', err);
       return res.redirect(`${FE_URL}/?error=login_failed`);
+    }
+  }
+
+  @Get('me')
+  async handleMe(@Res() res: Response) {
+    if (process.env.IS_MOCKING === 'true') {
+      return res.status(200).json({
+        kakaoId: 'unknown123',
+        nickname: 'GUEST',
+        email: 'guest@example.com',
+      });
     }
   }
 }


### PR DESCRIPTION
### 작업 내용

- Next.js 의 리덕스 유저 상태 관리를 위해 토큰 검증 없이 로그인 응답을 줄 필요 발생
-  Mocking 플래그가 true 일 경우 guest를 반환하는 컨트롤러 추가